### PR TITLE
Add "--force-confold" option to apt-get upgrade.

### DIFF
--- a/scripts/ansible.sh
+++ b/scripts/ansible.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eux
 
 # Install Ansible repository.
-apt-get -y update && apt-get -y upgrade
+apt-get -y update && apt-get -y -o Dpkg::Options::="--force-confold" upgrade
 apt-get -y install software-properties-common
 apt-add-repository ppa:ansible/ansible
 


### PR DESCRIPTION
Without this `apt-get upgrade` fails when a package update has a new
conflicting config file (as `sudo` did, recently).